### PR TITLE
Fix setting the root log message severity to the 'max' (severity) level of its sub-messages

### DIFF
--- a/flask_gcp_log_groups/gcp_logging.py
+++ b/flask_gcp_log_groups/gcp_logging.py
@@ -109,7 +109,7 @@ class GCPHandler(logging.Handler):
                 if (response.status_code >= 400 ):
                    severity = logging.getLevelName(logging.ERROR)
             else:
-                severity= min(self.mLogLevels)
+                severity= max(self.mLogLevels)
             self.mLogLevels=[]
             self.transport_parent.send(
                 None,


### PR DESCRIPTION
Currently, the root log message severity is set to the `min()` of its sub-messages severity (if any).  But this causes log threads with 'debug' and 'info' level logs to set the root log message severity to 'debug' instead of 'info'.

There is even a comment on [line 106](https://github.com/hiburrow/flask-gcp-log-groups/blob/025c69dbea4fde03b537d22a9b11ffa24e90d202/flask_gcp_log_groups/gcp_logging.py#L106) to "apply the max level to the root log message".

This PR replaces `min()` with `max()` to set the correct root level message severity.